### PR TITLE
Minor improvements

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
   };
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+    <main className="flex min-h-screen flex-col items-center justify-between p-4 md:p-24">
       <Card className="w-full max-w-2xl">
         <Header />
         <CardContent className="border-y border-slate-200 bg-slate-50/40 pt-6">
@@ -72,12 +72,13 @@ export default function Home() {
 const styles: Record<string, string> = {
   accordionTrigger:
     "font-semibold text-gray-500 hover:no-underline hover:text-gray-700 data-[state=open]:text-gray-800",
-  accordionSection: "pl-4"
+  accordionSection: "md:pl-4",
+  sectionContainer: "space-y-5 md:space-y-4"
 };
 
 const SectionOne = () => {
   return (
-    <div className="space-y-4">
+    <div className={styles.sectionContainer}>
       <Question title="給与収入" help="あなたの職業を選択してください。">
         <Input type="number" suffix="円" placeholder="給与収入" />
       </Question>
@@ -90,7 +91,7 @@ const SectionOne = () => {
 
 const SectionTwo = () => {
   return (
-    <div className="space-y-4">
+    <div className={styles.sectionContainer}>
       <Question title="配偶者の有無" help="あなたの職業を選択してください。">
         <YesNo name="001" value={false} onChange={() => {}} />
       </Question>
@@ -169,7 +170,7 @@ const SectionTwo = () => {
 
 const SectionThree = () => {
   return (
-    <div className="space-y-4">
+    <div className={styles.sectionContainer}>
       <Question
         title="社会保険料の金額"
         help="あなたの職業を選択してください。"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -79,10 +79,10 @@ const SectionOne = () => {
   return (
     <div className="space-y-4">
       <Question title="給与収入" help="あなたの職業を選択してください。">
-        <Input type="number" placeholder="給与収入" />
+        <Input type="number" suffix="円" placeholder="給与収入" />
       </Question>
       <Question title="仮想通貨の利益" help="あなたの職業を選択してください。">
-        <Input type="number" placeholder="仮想通貨の利益" />
+        <Input type="number" suffix="円" placeholder="仮想通貨の利益" />
       </Question>
     </div>
   );
@@ -98,7 +98,7 @@ const SectionTwo = () => {
         title="配偶者の給与収入"
         help="あなたの職業を選択してください。"
       >
-        <Input type="number" placeholder="配偶者の給与収入" />
+        <Input type="number" suffix="円" placeholder="配偶者の給与収入" />
       </Question>
       <Question
         title="寡婦に該当しますか？"
@@ -174,40 +174,40 @@ const SectionThree = () => {
         title="社会保険料の金額"
         help="あなたの職業を選択してください。"
       >
-        <Input type="number" placeholder="0" />
+        <Input type="number" suffix="円" placeholder="0" />
       </Question>
       <Question
         title="生命保険料の金額"
         help="あなたの職業を選択してください。"
       >
-        <Input type="number" placeholder="0" />
+        <Input type="number" suffix="円" placeholder="0" />
       </Question>
       <Question title="医療費の金額" help="あなたの職業を選択してください。">
-        <Input type="number" placeholder="0" />
+        <Input type="number" suffix="円" placeholder="0" />
       </Question>
       <Question
         title="小規模企業共済等掛金の金額"
         help="あなたの職業を選択してください。"
       >
-        <Input type="number" placeholder="0" />
+        <Input type="number" suffix="円" placeholder="0" />
       </Question>
       <Question
         title="地震保険料の金額"
         help="あなたの職業を選択してください。"
       >
-        <Input type="number" placeholder="0" />
+        <Input type="number" suffix="円" placeholder="0" />
       </Question>
       <Question
         title="住宅借入金等特別控除"
         help="あなたの職業を選択してください。"
       >
-        <Input type="number" placeholder="0" />
+        <Input type="number" suffix="円" placeholder="0" />
       </Question>
       <Question
         title="寄付金控除(ふるさと納税額)"
         help="あなたの職業を選択してください。"
       >
-        <Input type="number" placeholder="0" />
+        <Input type="number" suffix="円" placeholder="0" />
       </Question>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,11 +14,11 @@ import { Card, CardContent } from "@/components/ui/card";
 import { YesNo } from "@/components/yes-no";
 
 export default function Home() {
-  const calculatedResult: Record<string, number> = {
+  const calculatedResult: Record<string, number | null | undefined> = {
     給与所得控除: 1880000,
-    基礎控除: 480000,
-    "配偶者控除/配偶者特別控除": 380000,
-    扶養控除: 630000
+    基礎控除: null,
+    "配偶者控除/配偶者特別控除": null,
+    扶養控除: null
   };
 
   const calculatedTaxResult: Record<string, number> = {

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -10,12 +10,12 @@ export const Footer = ({
   calculatedResult,
   calculatedTaxResult
 }: FooterProps) => (
-  <CardFooter className="items-end space-x-6 pt-6 md:space-x-10">
-    <div className="relative w-40 shrink-0">
+  <CardFooter className="flex flex-col space-y-6 pt-6 md:flex-row md:items-end md:space-x-10 md:space-y-0">
+    <div className="w-40 shrink-0 md:relative">
       <img
         src="/tax-accountant-2.svg"
         alt="Crypto Tax Accountant"
-        className="absolute bottom-2 right-0 w-40"
+        className="bottom-2 right-0 w-40 md:absolute"
       />
     </div>
     <div className="w-full space-y-4 divide-y-2">

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -2,8 +2,8 @@ import { CardFooter } from "@/components/ui/card";
 import { numberToJpy } from "@/lib/utils";
 
 type FooterProps = {
-  calculatedResult: Record<string, number>;
-  calculatedTaxResult: Record<string, number>;
+  calculatedResult: Record<string, number | null | undefined>;
+  calculatedTaxResult: Record<string, number | null | undefined>;
 };
 
 export const Footer = ({
@@ -24,7 +24,11 @@ export const Footer = ({
           <div key={key} className="flex items-center justify-between py-2">
             <span>{key}</span>
             <span className="mx-2 inline-block font-semibold text-orange-500">
-              {numberToJpy(value)}
+              {value ? (
+                numberToJpy(value)
+              ) : (
+                <span className="blur">0000000</span>
+              )}
             </span>
           </div>
         ))}
@@ -34,7 +38,11 @@ export const Footer = ({
           <div key={key} className="flex items-center justify-between py-2">
             <span>{key}</span>
             <span className="mx-2 inline-block font-semibold text-orange-500">
-              {numberToJpy(value)}
+              {value ? (
+                numberToJpy(value)
+              ) : (
+                <span className="blur">000000</span>
+              )}
             </span>
           </div>
         ))}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -10,7 +10,7 @@ export const Header = () => (
         簡単な質問に答えるだけで、仮想通貨取引の税金を簡単に概算します。さっそく始めましょう！
       </CardDescription>
     </div>
-    <div className="order-1 flex h-auto w-full items-center justify-center pb-4 text-center md:relative md:order-2 md:w-24 md:pb-0 md:text-left">
+    <div className="order-1 flex h-auto w-full items-center justify-center pb-4 text-center md:relative md:order-2 md:w-36 md:shrink-0 md:pb-0 md:text-left">
       <img
         src="/tax-accountant.svg"
         alt="Crypto Tax Accountant"

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,8 +1,8 @@
 import { CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const Header = () => (
-  <CardHeader className="flex flex-row space-x-6">
-    <div className="space-y-4">
+  <CardHeader className="flex space-y-0 md:flex-row md:space-x-6">
+    <div className="order-2 space-y-3 md:order-1 md:space-y-4">
       <CardTitle className="text-xl font-bold text-slate-700">
         仮想通貨の税金計算シミュレーションツール
       </CardTitle>
@@ -10,11 +10,11 @@ export const Header = () => (
         簡単な質問に答えるだけで、仮想通貨取引の税金を簡単に概算します。さっそく始めましょう！
       </CardDescription>
     </div>
-    <div className="relative w-24 shrink-0">
+    <div className="order-1 flex h-auto w-full items-center justify-center pb-4 text-center md:relative md:order-2 md:w-24 md:pb-0 md:text-left">
       <img
         src="/tax-accountant.svg"
         alt="Crypto Tax Accountant"
-        className="right -0 absolute -top-2 w-28"
+        className="w-40 md:absolute md:-top-2 md:right-0 md:w-28"
       />
     </div>
   </CardHeader>

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -7,10 +7,10 @@ export const Input = ({
 }: React.InputHTMLAttributes<HTMLInputElement> & {
   suffix?: React.ReactNode | string;
 }) => (
-  <div className="relative w-48">
+  <div className="relative w-full md:w-48">
     <input
       className={cn(
-        "w-48 rounded-md border px-4 py-2.5 font-mono text-base",
+        "w-full rounded-md border px-4 py-2.5 font-mono text-base md:w-48",
         suffix ? "pr-8" : "pr-4",
         className
       )}

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -7,7 +7,7 @@ export const Input = ({
 }: React.InputHTMLAttributes<HTMLInputElement> & {
   suffix?: React.ReactNode | string;
 }) => (
-  <div className="relative">
+  <div className="relative w-48">
     <input
       className={cn(
         "w-48 rounded-md border px-4 py-2.5 font-mono text-base",

--- a/src/components/question.tsx
+++ b/src/components/question.tsx
@@ -11,14 +11,14 @@ export const Question = ({
   help?: React.ReactNode | string;
   children: React.ReactNode | string;
 }) => (
-  <div className="flex shrink-0 items-center justify-between">
-    <div className="flex items-center">
+  <div className="flex flex-col justify-between space-y-2 md:flex-row md:items-center md:space-y-0">
+    <div className="flex items-center justify-between md:justify-start">
       <div>
-        <h4 className="text-base font-semibold text-slate-700">{title}</h4>
+        <h4 className="font-semibold text-slate-700 md:text-base">{title}</h4>
         {description && <p className="text-sm text-slate-500">{description}</p>}
       </div>
       {help && <Help>{help}</Help>}
     </div>
-    {children}
+    <div>{children}</div>
   </div>
 );

--- a/src/components/yes-no.tsx
+++ b/src/components/yes-no.tsx
@@ -20,7 +20,7 @@ export const YesNo = ({
   };
 
   return (
-    <div className="flex h-9 items-center space-x-5">
+    <div className="flex items-center space-x-5 md:h-9">
       <div className="flex items-center space-x-2">
         <input
           type="radio"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,6 +8,7 @@ export function cn(...inputs: ClassValue[]) {
 export function numberToJpy(value: number) {
   return new Intl.NumberFormat("ja-JP", {
     style: "currency",
-    currency: "JPY"
+    currency: "JPY",
+    currencyDisplay: "name"
   }).format(value);
 }


### PR DESCRIPTION
This PR adds a couple of minor improvements to the UI.

- All money related input now has `円` suffix
- `numberToJpy` function also follows the same convention of displaying `円` symbol after the figure
- Makes the UI responsive so that it looks good in mobile devices as well

Mobile view:
<img width="388" alt="image" src="https://github.com/ue-sho/crypto-tax-simulator/assets/3870529/173da666-9eb2-4c7c-b8d5-5632c74e4604">

Web View:
<img width="1116" alt="image" src="https://github.com/ue-sho/crypto-tax-simulator/assets/3870529/1080e09a-d83e-42d3-9d0e-33c1d5a9c2de">



All monetary figures/numbers now follow the same convention (number followed by `円` symbol)
<img width="386" alt="image" src="https://github.com/ue-sho/crypto-tax-simulator/assets/3870529/a024ddad-e7c9-4995-b26b-49e8697489cc">

Update: a small visual enhancement, instead of changing the calculation section we can simply blur out the information that we don't have yet. See screenshot below:
<img width="781" alt="image" src="https://github.com/ue-sho/crypto-tax-simulator/assets/3870529/fe85ddf9-f1e1-4d58-8f48-c9d910d957c4">


