### PR TITLE
add missing hover/help text

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -134,7 +134,7 @@ const SectionOne = ({ setState }: SectionProps) => {
         <div>
           <Question
             title="仮想通貨の利益"
-            help="あなたの職業を選択してください。"
+            help="総平均法で計算した実現損益を入力してください。"
           >
             <Input
               type="number"


### PR DESCRIPTION
Sorry I think I missed this in earlier commit.

<img width="757" alt="image" src="https://github.com/ue-sho/crypto-tax-simulator/assets/3870529/4003eafc-9c10-423a-a6d1-26ede09f7698">
